### PR TITLE
remove unnecessary lines from bitcoind profile

### DIFF
--- a/usr/share/onion-grater-merger/examples/40_bitcoind.yml
+++ b/usr/share/onion-grater-merger/examples/40_bitcoind.yml
@@ -18,7 +18,4 @@
       ## Testnet onion service.
       - pattern:     'NEW:(\S+) Port=18333,127.0.0.1:18333'
         replacement: 'NEW:{} Port=18333,{client-address}:18333 Flags=DiscardPK'
-      ## Needed to make services ephemeral.
-      - pattern:     '250-PrivateKey=(\S+):\S+'
-        replacement: '250-PrivateKey={}:redacted'
       ## }}}


### PR DESCRIPTION
With `Flags=DiscardPK` in the `ADD_ONION` command the private key is already redacted. These lines were redundant.