### PR TITLE
Fix seccomp filter for ppc64le

### DIFF
--- a/lib/systemd/system/onion-grater.service
+++ b/lib/systemd/system/onion-grater.service
@@ -44,7 +44,7 @@ ProtectControlGroups=yes
 NoNewPrivileges=yes
 RestrictRealtime=yes
 RestrictNamespaces=yes
-SystemCallFilter=stat close open mmap fstat rt_sigaction read munmap mprotect readlink getdents write lstat poll lseek brk rt_sigprocmask ioctl access dup getpid socket connect sendto recvmsg bind listen getsockname getpeername setsockopt execve uname fcntl getrlimit sysinfo getuid getgid geteuid getegid sigaltstack statfs arch_prctl futex set_tid_address set_robust_list getrandom openat getdents64 getcwd accept4 clone recvfrom shutdown madvise pipe2 dup2 wait4 mkdir fchownat
+SystemCallFilter=stat close open mmap fstat rt_sigaction read munmap mprotect readlink getdents write lstat poll lseek brk rt_sigprocmask ioctl access dup getpid socket connect sendto recvmsg bind listen getsockname getpeername setsockopt execve uname fcntl getrlimit sysinfo getuid getgid geteuid getegid sigaltstack statfs arch_prctl futex set_tid_address set_robust_list getrandom openat getdents64 getcwd accept4 clone recvfrom shutdown madvise pipe2 dup2 wait4 mkdir fchownat _llseek send recv
 SystemCallArchitectures=native
 
 [Install]


### PR DESCRIPTION
On ppc64le, `_llseek` and `send` are used as soon as onion-grater launches; `recv` is used when Ricochet tries to connect.