### PR TITLE
update 40_bitcoind.yml to work with bitcoind v0.21

### DIFF
--- a/usr/share/doc/onion-grater-merger/examples/40_bitcoind.yml
+++ b/usr/share/doc/onion-grater-merger/examples/40_bitcoind.yml
@@ -22,7 +22,11 @@
       ## {{{ Mainnet onion service.
       - pattern:     'NEW:(\S+) Port=8333,127.0.0.1:8333'
         replacement: 'NEW:{} Port=8333,{client-address}:8333 Flags=DiscardPK'
+      - pattern:     'NEW:(\S+) Port=8333,127.0.0.1:8334'
+        replacement: 'NEW:{} Port=8333,{client-address}:8334 Flags=DiscardPK'
       ## Testnet onion service.
       - pattern:     'NEW:(\S+) Port=18333,127.0.0.1:18333'
         replacement: 'NEW:{} Port=18333,{client-address}:18333 Flags=DiscardPK'
+      - pattern:     'NEW:(\S+) Port=18333,127.0.0.1:18334'
+        replacement: 'NEW:{} Port=18333,{client-address}:18334 Flags=DiscardPK'
       ## }}}


### PR DESCRIPTION
Bitcoin Core will use v3 onions by default, and has slightly modified their control port commands, starting in version 0.21. The new exchange looks like this when using this onion-grater profile (on testnet):

```
PROTOCOLINFO 1
250-PROTOCOLINFO 1
250-AUTH METHODS=NULL
250-VERSION Tor="0.4.4.6"
250 OK
AUTHENTICATE
250 OK
ADD_ONION NEW:ED25519-V3 Port=18333,127.0.0.1:18334
250-ServiceID=tncwim2maogphaeqmfq2vxjwtitkxihtmjhfsqzpgfjvukfwat2s74ad
250 OK
```

With these modifications the profile will now work with old and new versions of bitcoin.