### PR TITLE
Improve bitcoind onion-grater profile

### DIFF
--- a/usr/share/doc/onion-grater-merger/examples/40_bitcoind.yml
+++ b/usr/share/doc/onion-grater-merger/examples/40_bitcoind.yml
@@ -30,13 +30,13 @@
   commands:
     ADD_ONION:
       ## {{{
-      - pattern:     'NEW:(\S+) Port=8333,(?:127.0.0.1|0.0.0.0):8334'
+      - pattern:     'NEW:(\S+) Port=8333,(?:127\.0\.0\.1|0\.0\.0\.0|10\.152\.152\.\d{1.3}):8334'
         replacement: 'NEW:{} Port=8333,{client-address}:8334 Flags=DiscardPK'
-      - pattern:     'NEW:(\S+) Port=18333,(?:127.0.0.1|0.0.0.0):18334'
+      - pattern:     'NEW:(\S+) Port=18333,(?:127\.0\.0\.1|0\.0\.0\.0|10\.152\.152\.\d{1.3}):18334'
         replacement: 'NEW:{} Port=18333,{client-address}:18334 Flags=DiscardPK'
-      - pattern:     'NEW:(\S+) Port=38333,(?:127.0.0.1|0.0.0.0):38334'
+      - pattern:     'NEW:(\S+) Port=38333,(?:127\.0\.0\.1|0\.0\.0\.0|10\.152\.152\.\d{1.3}):38334'
         replacement: 'NEW:{} Port=38333,{client-address}:38334 Flags=DiscardPK'
-      - pattern:     'NEW:(\S+) Port=18444,(?:127.0.0.1|0.0.0.0):18445'
+      - pattern:     'NEW:(\S+) Port=18444,(?:127\.0\.0\.1|0\.0\.0\.0|10\.152\.152\.\d{1.3}):18445'
         replacement: 'NEW:{} Port=18444,{client-address}:18445 Flags=DiscardPK'
       ## }}}
 

--- a/usr/share/doc/onion-grater-merger/examples/40_lnd.yml
+++ b/usr/share/doc/onion-grater-merger/examples/40_lnd.yml
@@ -1,0 +1,32 @@
+## onion-grater profile for LND (https://github.com/lightningnetwork/lnd)
+## Following will be enabled:
+## - ADD_ONION for new V3 onions at port 9735 and 9911
+## - Re-creating previous onions at aforementioned ports
+## - DEL_ONION
+
+## LND will create an onion service for P2P at port 9735
+## Optionally, an onion service that will act as an LND Watchtower
+## can be enabled at port 9911
+## LND will re-use old onion services which is why simply creating
+## new onion services does not suffice.
+
+---
+- exe-paths:
+    - '*'
+  users:
+    - '*'
+  hosts:
+    - '*'
+  commands:
+    ADD_ONION:
+      - pattern: 'NEW:ED25519-V3 Port=9735,9735 '
+        replacement: 'NEW:ED25519-V3 Port=9735,{client-address}:9735'
+      - pattern: 'NEW:ED25519-V3 Port=9911,9911 '
+        replacement: 'NEW:ED25519-V3 Port=9911,{client-address}:9911'
+      - pattern: 'ED25519-V3:(\S+) Port=9735,9735 '
+        replacement: 'ED25519-V3:(\S+) Port=9735,{client-address}:9735'
+      - pattern: 'ED25519-V3:(\S+) Port=9911,9911 '
+        replacement: 'ED25519-V3:(\S+) Port=9911,{client-address}:9911'
+    DEL_ONION:
+      - '.+'
+

--- a/usr/share/doc/onion-grater-merger/examples/40_lnd.yml
+++ b/usr/share/doc/onion-grater-merger/examples/40_lnd.yml
@@ -24,9 +24,9 @@
       - pattern: 'NEW:ED25519-V3 Port=9911,9911 '
         replacement: 'NEW:ED25519-V3 Port=9911,{client-address}:9911'
       - pattern: 'ED25519-V3:(\S+) Port=9735,9735 '
-        replacement: 'ED25519-V3:(\S+) Port=9735,{client-address}:9735'
+        replacement: 'ED25519-V3:{} Port=9735,{client-address}:9735'
       - pattern: 'ED25519-V3:(\S+) Port=9911,9911 '
-        replacement: 'ED25519-V3:(\S+) Port=9911,{client-address}:9911'
+        replacement: 'ED25519-V3:{} Port=9911,{client-address}:9911'
     DEL_ONION:
       - '.+'
 


### PR DESCRIPTION
It is infact not necessary to use `bind=0.0.0.0:8334=onion` in bitcoind.conf. It is only necessary with the current version of the profile. I've added support to use `bind=10.152.152.XX:8334=onion`. When `0.0.0.0` is used, `bitcoin-cli -netinfo` incorrectly displays incoming onion connections as npr. I've tested this profile and it will classify them correctly after the change. I assume the problem is binding to `0.0.0.0`.

I also fixed the fact that dots are not being escaped in the patterns.

Please be mindful of any typos.