### PR TITLE
Write 250 OK in the same syscall as its \r\n

### DIFF
--- a/usr/lib/onion-grater
+++ b/usr/lib/onion-grater
@@ -254,9 +254,9 @@ class FilteredControlPortProxySession:
         if line.isspace():
             return
         self.debug_log_send(line)
-        self.wfile.write(bytes(line, 'ascii'))
         if not raw:
-            self.wfile.write(bytes("\r\n", 'ascii'))
+            line += "\r\n"
+        self.wfile.write(bytes(line, 'ascii'))
         self.wfile.flush()
 
     def get_rule(self, cmd, arg_str):


### PR DESCRIPTION
## Changes

Two `.write()` calls means this decoded to `sendto("250 OK"); sendto("\r\n")`, and the same happened to all the other responses

We don't have writev here but we can just expand line, which works perfectly

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.whonix.org/wiki/Terms_of_Service), [Privacy Policy](https://www.whonix.org/wiki/Privacy_Policy), [Cookie Policy](https://www.whonix.org/wiki/Cookie_Policy), [E-Sign Consent](https://www.whonix.org/wiki/E-Sign_Consent), [DMCA](https://www.whonix.org/wiki/DMCA), [Imprint](https://www.whonix.org/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [x] I am providing new code and test(s) for it
